### PR TITLE
Replace raw SQL queries with ORM queries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM python:3.12.2-alpine
 
-WORKDIR /app
+WORKDIR /api
 
 RUN pip install "fastapi[all]"
 
-VOLUME ["/app"]
+VOLUME ["/api"]
 EXPOSE 8000
 
-COPY requirements.txt .
-RUN pip install -r requirements.txt
+COPY requirements.txt /tmp
+RUN pip install -r /tmp/requirements.txt
 
 CMD [ "uvicorn", "main:app", "--reload", "--host", "0.0.0.0"]

--- a/api/crud.py
+++ b/api/crud.py
@@ -1,0 +1,11 @@
+from sqlalchemy.orm import Session
+
+import models
+
+
+def get_posts(db: Session, skip: int = 0, limit: int = 100):
+    return db.query(models.Post).offset(skip).limit(limit).all()
+
+
+def get_post(db: Session, id: int):
+    return db.query(models.Post).filter(models.Post.id == id).first()

--- a/api/crud.py
+++ b/api/crud.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, Query
 
 import models
 
@@ -7,5 +7,9 @@ def get_posts(db: Session, skip: int = 0, limit: int = 100):
     return db.query(models.Post).offset(skip).limit(limit).all()
 
 
-def get_post(db: Session, id: int):
-    return db.query(models.Post).filter(models.Post.id == id).first()
+def post_query_by_id(db: Session, id: int) -> Query:
+    return db.query(models.Post).filter(models.Post.id == id)
+
+
+def get_post_by_id(db: Session, id: int) -> models.Post:
+    return post_query_by_id(db, id).first()

--- a/api/database.py
+++ b/api/database.py
@@ -1,0 +1,24 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+# SQLALCHEMY_DB_URL = 'postgresql://<username>:<password>@<host>:<port>/<database_name>'
+SQLALCHEMY_DB_URL = 'postgresql+psycopg://postgres:postgres@db:5432/fastapi-yt-sanjeev'
+
+
+engine = create_engine(SQLALCHEMY_DB_URL)
+
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+Base = declarative_base()
+
+
+# Dependency
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/api/main.py
+++ b/api/main.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 import psycopg
 from psycopg.rows import dict_row
 
-import crud, models
+import crud, models, schemas
 from database import engine, get_db
 
 
@@ -17,13 +17,6 @@ models.Base.metadata.create_all(bind=engine)
 
 
 app = FastAPI()
-
-
-class Post(BaseModel):
-    title: str
-    content: str
-    published: bool = True
-    # rating: Optional[int] = None
 
 
 class MyDatabase(object):
@@ -74,54 +67,66 @@ async def get_posts(db: Session = Depends(get_db)):
 
 
 @app.post("/posts", status_code=status.HTTP_201_CREATED)
-async def create_post(post: Post): # can be any variable name
-    db.cursor.execute("""INSERT INTO posts (title, content, published) 
-                          VALUES (%s, %s, %s) RETURNING * """,
-                          (post.title, post.content, post.published))
+async def create_post(post: schemas.PostCreate, db: Session = Depends(get_db)):
+    """ INSERT INTO posts (title, content, published) 
+            VALUES (%s, %s, %s) RETURNING *,
+            (post.title, post.content, post.published))"""
     
-    new_post = db.cursor.fetchone()
-    db.conn.commit()
+    new_post = models.Post(**post.model_dump())
+    
+    # add new post object to the db
+    db.add(new_post)
+
+    # commit changes to db store
+    db.commit()
+
+    # replace 'new_post' with the refreshed version from the database
+    db.refresh(new_post)
+
     return { "data": new_post }
     
 
 @app.get("/posts/{id}")
-async def get_post(id: int):
-    db.cursor.execute("""SELECT * FROM posts WHERE id = %s""", (id,))
-    query_post = db.cursor.fetchone()
+async def get_post(id: int, db: Session = Depends(get_db)):
+    # """SELECT * FROM posts WHERE id = %s""", (id,))
+    query_post = crud.get_post_by_id(db, id)
 
     if query_post == None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
-                            detail=f"Post with id:{id} was not found.")
+                            detail=f"Post with id: {id} was not found.")
 
     return { "post_detail": query_post }
     
     
 @app.delete("/posts/{id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_post(id: int):
-    db.cursor.execute("""DELETE FROM posts WHERE id = %s RETURNING *""", (id,))
-    del_post = db.cursor.fetchone()
+async def delete_post(id: int, db: Session = Depends(get_db)):
+    # """DELETE FROM posts WHERE id = %s RETURNING *""", (id,))
+    del_post = crud.post_query_by_id(db, id)
 
-    if del_post == None:
+    if del_post.first() == None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail=f"Unable to delete post with id:{id}. Post was not found.")
     
-    db.conn.commit()
+    del_post.delete(synchronize_session=False)
+    db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
     
     
 @app.put("/posts/{id}")
-async def update_post(id: int, post: Post):
-    db.cursor.execute("""
-                      UPDATE posts
-                        SET title = %s, content = %s, published = %s
-                        WHERE id = %s RETURNING *""",
-                        (post.title, post.content, post.published, id))
-    upd_post = db.cursor.fetchone()
+async def update_post(id: int, post: schemas.PostUpdate, db: Session = Depends(get_db)):
+    """
+        UPDATE posts
+        SET title = %s, content = %s, published = %s
+        WHERE id = %s RETURNING *,
+        (post.title, post.content, post.published, id))"""
+    upd_query = crud.post_query_by_id(db, id)
 
-    if upd_post == None:
+    if upd_query.first() == None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail=f"Post with id:{id} was not found.")
     
-    db.conn.commit()
-    return {"post_detail": upd_post}
+    upd_query.update(post.model_dump(),
+                     synchronize_session=False)
+    db.commit()
+    return {"post_detail": upd_query.first()}
     

--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from database import Base
+
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+    content = Column(String, nullable=False)
+    published = Column(Boolean, default=True)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class PostBase(BaseModel):
+    title: str
+    content: str
+    published: bool = True
+    # rating: Optional[int] = None
+
+
+class PostCreate(PostBase):
+    pass
+
+
+class PostUpdate(PostBase): 
+    published: bool

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./api:/app:ro
+      - ./api:/api:ro
     depends_on:
       db:
         condition: service_healthy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi[all]
 uvicorn
 psycopg[binary]
+SQLAlchemy==2.0.*


### PR DESCRIPTION
Replaced all of the SQL raw queries in the API's CRUD methods with the ORM-provided queries instead.
- Added crud.py to store some common query functions
- Added schemas.py to store the Pydantic models
- Added models.py to store the ORM/database models

Tests:

- [x] Test all API endpoint in Postman